### PR TITLE
trac 12219: catch IOError from urllib when uploading https worksheet and...

### DIFF
--- a/flask_version/worksheet_listing.py
+++ b/flask_version/worksheet_listing.py
@@ -261,7 +261,13 @@ def upload_worksheet():
             # Or shall we try to import the document as an sws in doubt?
             return current_app.message("Unknown worksheet extension: %s. %s" % (extension, backlinks))
         filename = tmp_filename()+extension
-        urllib.urlretrieve(url, filename)
+        try:
+            urllib.urlretrieve(url, filename)
+        except IOError as err:
+            if err.strerror == 'unknown url type' and err.filename == 'https':
+                return current_app.message(_("This Sage notebook is not configured to load worksheets from 'https' URLs. Try a different URL or download the worksheet and upload it directly from your computer.\n%(backlinks)s",backlinks=backlinks))
+            else:
+                raise
     else:
         #Uploading a file from the user's computer
         dir = tmp_dir()


### PR DESCRIPTION
... no ssl available.

I'm also posting this patch on trac as usual, but I'm learning some git and seeing how a github branch/pull request workflow would, uh, work. 
