### PR TITLE
Include twisted in the dependencies of the spkg.

### DIFF
--- a/SPKG.txt
+++ b/SPKG.txt
@@ -24,12 +24,12 @@ GPLv2+
 
  * Python >= 2.6.4
  * jinja2 >= 2.5.5
- * Twisted >= 11.0.0
  * Sphinx >= 1.0.4 (pretty docstrings)
 
  Included dependencies (for specific version numbers, see the
  spkg-dist file):
 
+ * twisted
  * pytz
  * Babel
  * Werkzeug

--- a/spkg-dist
+++ b/spkg-dist
@@ -88,7 +88,8 @@ def fetch_packages():
     tmp_dir = mkdtemp()
 
     # in order of dependencies
-    required_packages = ('pytz>=2011n',
+    required_packages = ('twisted>=11.0.0',
+                         'pytz>=2011n',
                          'Babel>=0.9.6',
                          'Werkzeug>=0.8.2',
                          'speaklater>=1.2',


### PR DESCRIPTION
This does away with the need for a separate twisted spkg in Sage.
