### PR TITLE
use title instead of alt to show tooltip

### DIFF
--- a/sagenb/data/sage/html/notebook/cell.html
+++ b/sagenb/data/sage/html/notebook/cell.html
@@ -58,7 +58,7 @@ INPUT:
                     <a href="javascript:evaluate_cell({{ '%r'|format(cell.id()) }}, 0);"
                        class="eval_button_active"
                        id="eval_button{{ cell.id() }}"
-                       alt="Click here to reset this interactive cell">
+                       title="Click here to reset this interactive cell">
                         reset
                     </a>
                 {% endif %}
@@ -77,7 +77,7 @@ INPUT:
                 <a href="javascript:evaluate_cell({{ '%r'|format(cell.id()) }}, 0);"
                    class="eval_button"
                    id="eval_button{{ cell.id() }}" 
-                   alt="{{ gettext('Click here or press shift-return to evaluate') }}">
+                   title="{{ gettext('Click here or press shift-return to evaluate') }}">
                     {{ gettext('evaluate') }}
                 </a>
             {% endif %}


### PR DESCRIPTION
The text to explain the evaluate <a> link doesn't appear.

Using the title property instead of the alt property tells the browser to render it as a tooltip when a mouse-over event is detected on the <a> link.

see: http://www.w3.org/TR/html401/struct/global.html#adef-title
