### PR TITLE
MathJax: fix doctest in sphinxify.py

### DIFF
--- a/sagenb/misc/sphinxify.py
+++ b/sagenb/misc/sphinxify.py
@@ -71,7 +71,7 @@ def sphinxify(docstring, format='html'):
         sage: sphinxify('**Testing**\n`monospace`')
         '\n<div class="docstring"...<strong>Testing</strong>\n<span class="math"...</p>\n\n\n</div>'
         sage: sphinxify('`x=y`')
-        '\n<div class="docstring">\n    \n  <p><span class="math">x=y</span></p>\n\n\n</div>'
+        '\n<div class="docstring">\n    \n  <p><span class="math">\\(x=y\\)</span></p>\n\n\n</div>'
         sage: sphinxify('`x=y`', format='text')
         'x=y\n'
         sage: sphinxify(':math:`x=y`', format='text')


### PR DESCRIPTION
See http://trac.sagemath.org/sage_trac/ticket/9774#comment:76: with the change from jsMath to MathJax, there is a doctest failure in sphinxify.py.
