### PR TITLE
use input buttons for evaluate buttons

### DIFF
--- a/sagenb/data/sage/html/notebook/cell.html
+++ b/sagenb/data/sage/html/notebook/cell.html
@@ -68,12 +68,11 @@ INPUT:
                 <textarea class="{{ input_cls }}" rows="{{ (1, cell.input_text().strip()|number_of_rows(80))|max }}"
                           cols="80"
                           id="cell_input_{{ cell.id() }}">{{ cell.input_text().rstrip() }}</textarea>
-                <a href="javascript:evaluate_cell({{ '%r'|format(cell.id()) }}, 0);"
+                <input type="button"
                    class="eval_button"
                    id="eval_button{{ cell.id() }}" 
-                   title="{{ gettext('Click here or press shift-return to evaluate') }}">
-                    {{ gettext('evaluate') }}
-                </a>
+                   title="{{ gettext('Click here or press shift-return to evaluate') }}"
+                   value="{{ gettext('evaluate') }}" />
             {% endif %}
             {# end input #}
 

--- a/sagenb/data/sage/js/notebook_lib.js
+++ b/sagenb/data/sage/js/notebook_lib.js
@@ -379,6 +379,11 @@ function bind_events() {
         var cell_id = get_cell_id_from_id(id);
         return input_keypress(cell_id, event);
     });
+    $('.eval_button').click(function () {
+        var id = $(this).attr("id");
+        var cell_id = get_cell_id_from_id(id);
+        evaluate_cell(cell_id, 0);
+    }
 }
 
 

--- a/sass/src/main.scss
+++ b/sass/src/main.scss
@@ -862,7 +862,7 @@ div {
 textarea.cell_input:hover {
   cursor: text; }
 
-a {
+input {
   &.eval_button {
     display: none; }
   &.eval_button_active {


### PR DESCRIPTION
An user might think that an anchor link brings him to another page. Having buttons instead would make more sense here as it is an action rather than a link.
