### PR TITLE
Expand tildes in upload argument

### DIFF
--- a/sagenb/notebook/run_notebook.py
+++ b/sagenb/notebook/run_notebook.py
@@ -468,7 +468,15 @@ def notebook_run(self,
 
     # Turn it into a full path for later conversion to a file URL
     if upload:
-        upload = os.path.abspath(upload)
+        upload_abs = os.path.abspath(upload)
+        if os.path.exists(upload_abs):
+            upload = upload_abs
+        else:
+            # They might have expected ~ to be expanded to their user directory
+            upload = os.path.expanduser(upload)
+            if not os.path.exists(upload):
+                raise ValueError("Unable to find the file %s to upload" % upload)
+
 
     if subnets is not None:
         raise ValueError("""The subnets parameter is no longer supported. Please use a firewall to block subnets, or even better, volunteer to write the code to implement subnets again.""")


### PR DESCRIPTION
Since shell quoting can be confusing, allowing tilde expansion for uploading files (even when quoted) might be useful.  See [comments](https://github.com/sagemath/sagenb/pull/31#issuecomment-6525903) on [issue #31](https://github.com/sagemath/sagenb/pull/31).

I also throw an exception if the file can't be found.
