### PR TITLE
sage.misc.latex_macros: do not evaluate anything on startup. 

### DIFF
--- a/sagenb/misc/sphinxify.py
+++ b/sagenb/misc/sphinxify.py
@@ -299,7 +299,7 @@ if (os.environ.get('SAGE_DOC_MATHJAX', False)
     mathjax_path = 'MathJax.js?config=TeX-AMS_HTML-full,../mathjax_sage.js'
 
     from sage.misc.latex_macros import sage_mathjax_macros
-    html_theme_options['mathjax_macros'] = sage_mathjax_macros
+    html_theme_options['mathjax_macros'] = sage_mathjax_macros()
 
     from pkg_resources import Requirement, working_set
     sagenb_path = working_set.find(Requirement.parse('sagenb')).location
@@ -403,14 +403,14 @@ latex_elements['preamble'] = '\usepackage{amsmath}\n\usepackage{amssymb}\n'
 try:
     from sage.misc.latex_macros import sage_latex_macros
 except ImportError:
-    sage_latex_macros = []
+    def sage_latex_macros(): return []
 
 try:
     pngmath_latex_preamble  # check whether this is already defined
 except NameError:
     pngmath_latex_preamble = ""
 
-for macro in sage_latex_macros:
+for macro in sage_latex_macros():
     # used when building latex and pdf versions
     latex_elements['preamble'] += macro + '\n'
     # used when building html version


### PR DESCRIPTION
Right now, `sage.misc.latex_macros` evaluates lots of things on startup. This is modified at [#13504](http://trac.sagemath.org/sage_trac/ticket/13504): the list `sage_latex_macros` has been converted to a function. This contains the changes necessary to make sagenb compatible.
