### PR TITLE
jQuery reference repair in graph_editor

### DIFF
--- a/sagenb/data/graph_editor/graph_editor.html
+++ b/sagenb/data/graph_editor/graph_editor.html
@@ -26,7 +26,7 @@
           margin: 10px;
       }
     </style>  
-    <script type="text/javascript" src="/javascript/jquery/jquery-1.5.2.min.js"></script>
+    <script type="text/javascript" src="/javascript/jquery/jquery-1.7.1.min.js"></script>
     <link rel="stylesheet" href="/javascript/jqueryui/css/sage/jquery-ui-1.8.11.custom.css" />
     <script type="text/javascript" src="/javascript/jqueryui/js/jquery-ui-1.8.11.custom.min.js"></script>
     <script type="text/javascript" src="/javascript/graph_editor/processing.editor.min.js"></script>


### PR DESCRIPTION
This error was responsible for long unusability of graph_editor. See http://ask.sagemath.org/question/879/graph-editor-doesnt-work .
