### PR TITLE
Fix the version of the flask openid extension to avoid import problems

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ def all_files(dir, prefix):
 
 install_requires = [ 'twisted>=11.0.0'
                    , 'flask'
-                   , 'flask-openid'
+                   , 'flask-openid==1.0.1'
                    , 'flask-autoindex'
                    , 'babel'
                    , 'flask-babel'

--- a/util/fetch_deps.py
+++ b/util/fetch_deps.py
@@ -19,7 +19,7 @@ required_packages = [ 'zope.interface'
                     , 'Flask-Silk>=0.1.1'
                     , 'Flask-AutoIndex>=0.4.0'
                     , 'Flask-Babel>=0.8'
-                    , 'Flask-OpenID>=1.0.1'
+                    , 'Flask-OpenID==1.0.1' # version 1.1 changes the import interface from 'import flaskext.openid' to 'import flask_openid'
                     , 'webassets>=0.7.1'
                     ]
 


### PR DESCRIPTION
Version 1.1 of the flask openid extension changes the import from `import flaskext.openid` to `import flask_openid`.  These changes aren't even in the flask openid git repository, so I'm not sure what is going on.  I posted to the flask mailing list about this as of 2012-11-21.
