### PR TITLE
Fix for Sage ticket #13678, allow tab completion of matrix constructor.

### DIFF
--- a/sagenb/notebook/interact.py
+++ b/sagenb/notebook/interact.py
@@ -2639,6 +2639,8 @@ def interact(f, layout=None, width='800px'):
         ...         html('There is no solution to $$%s x=%s$$'%(latex(A), latex(v)))
         <html>...
     """
+    if not isinstance(f, types.FunctionType) and callable(f):
+        f = f.__call__
     (args, varargs, varkw, defaults) = inspect.getargspec(f)
 
     if defaults is None:


### PR DESCRIPTION
See [Sage #13678](http://trac.sagemath.org/sage_trac/ticket/13678).
