### PR TITLE
Mac zip files cause an error

### DIFF
--- a/flask_version/worksheet_listing.py
+++ b/flask_version/worksheet_listing.py
@@ -391,7 +391,10 @@ def upload_worksheet():
                 zip_file = zipfile.ZipFile(filename)
                 for subfilename in zip_file.namelist():
                     prefix, extension = os.path.splitext(subfilename)
-                    if extension in ['.sws', '.html', '.txt', '.rst'] :
+                    # Mac zip files contain files like __MACOSX/._worksheet.sws
+                    # which are metadata files, so we skip those as
+                    # well as any other files we won't understand
+                    if extension in ['.sws', '.html', '.txt', '.rst'] and not prefix.startswith('__MACOSX/'):
                         tmpfilename = os.path.join(dir, "tmp" + extension)
                         try:
                             tmpfilename = zip_file.extract(subfilename, tmpfilename)


### PR DESCRIPTION
Apple in their wisdom creates metadata files like `__MACOSX/._worksheet.sws` in zip files.  The problem is that Sage tries to open such files as `sws` files and predictably fails.  This then leads to all sorts of unpleasantness.

I'm not sure a regex is the best way to handle it, but I couldn't find out how to use the zip metadata to ignore it based on some flag, but maybe someone else knows better.
