### PR TITLE
properly handle directories not ending in .sagenb

### DIFF
--- a/sagenb/notebook/run_notebook.py
+++ b/sagenb/notebook/run_notebook.py
@@ -505,7 +505,7 @@ def notebook_run(self,
         directory = '%s/sage_notebook.sagenb' % DOT_SAGENB
     else:
         directory = directory.rstrip('/')
-        if directory[-7:] != '.sagenb':
+        if not directory.endswith('.sagenb'):
             directory += '.sagenb'
 
     # First change to the directory that contains the notebook directory


### PR DESCRIPTION
Currently, supplying directory names without .sagenb extension results in a spectacular fail. This is a serious regression.
