### PR TITLE
Adapt to new Flask extension module schema

### DIFF
--- a/flask_version/admin.py
+++ b/flask_version/admin.py
@@ -1,7 +1,7 @@
 import os
 from flask import Module, url_for, render_template, request, session, redirect, g, current_app
 from decorators import login_required, admin_required, with_lock
-from flaskext.babel import Babel, gettext, ngettext, lazy_gettext
+from flask.ext.babel import Babel, gettext, ngettext, lazy_gettext
 _ = gettext
 
 admin = Module('flask_version.admin')
@@ -107,7 +107,7 @@ def notebook_settings():
         
     #Make changes to the default language used
     if 'default_language' in request.values:
-        from flaskext.babel import refresh
+        from flask.ext.babel import refresh
         refresh()
         current_app.config['BABEL_DEFAULT_LOCALE'] = request.values['default_language']
         

--- a/flask_version/authentication.py
+++ b/flask_version/authentication.py
@@ -2,7 +2,7 @@ import os
 import random
 from flask import Module, url_for, render_template, request, session, redirect, g, current_app
 from decorators import with_lock
-from flaskext.babel import gettext, ngettext, lazy_gettext
+from flask.ext.babel import gettext, ngettext, lazy_gettext
 _ = gettext
 
 authentication = Module('flask_version.authentication')

--- a/flask_version/base.py
+++ b/flask_version/base.py
@@ -5,10 +5,10 @@ from flask import Flask, Module, url_for, render_template, request, session, red
 from decorators import login_required, guest_or_login_required, with_lock
 from decorators import global_lock
 
-from flaskext.autoindex import AutoIndex
+from flask.ext.autoindex import AutoIndex
 SRC = os.path.join(os.environ['SAGE_ROOT'], 'devel', 'sage', 'sage')
 from flask.ext.openid import OpenID
-from flaskext.babel import Babel, gettext, ngettext, lazy_gettext, get_locale
+from flask.ext.babel import Babel, gettext, ngettext, lazy_gettext, get_locale
 from sagenb.misc.misc import SAGENB_ROOT, DATA, SAGE_DOC, translations_path
 
 oid = OpenID()

--- a/flask_version/decorators.py
+++ b/flask_version/decorators.py
@@ -1,6 +1,6 @@
 from functools import wraps
 from flask import Flask, url_for, render_template, request, session, redirect, g, current_app
-from flaskext.babel import Babel, gettext, ngettext, lazy_gettext
+from flask.ext.babel import Babel, gettext, ngettext, lazy_gettext
 _ = gettext
 
 from threading import Lock

--- a/flask_version/worksheet.py
+++ b/flask_version/worksheet.py
@@ -3,7 +3,7 @@ from functools import wraps
 from flask import Module, url_for, render_template, request, session, redirect, g, current_app
 from decorators import login_required, with_lock
 from collections import defaultdict
-from flaskext.babel import Babel, gettext, ngettext, lazy_gettext
+from flask.ext.babel import Babel, gettext, ngettext, lazy_gettext
 _ = gettext
 
 from sagenb.notebook.interact import INTERACT_UPDATE_PREFIX

--- a/flask_version/worksheet_listing.py
+++ b/flask_version/worksheet_listing.py
@@ -4,7 +4,7 @@ import os
 import urllib, urlparse
 from flask import Module, url_for, render_template, request, session, redirect, g, current_app
 from decorators import login_required, guest_or_login_required, with_lock
-from flaskext.babel import Babel, gettext, ngettext, lazy_gettext
+from flask.ext.babel import Babel, gettext, ngettext, lazy_gettext
 _ = gettext
 
 worksheet_listing = Module('flask_version.worksheet_listing')

--- a/sagenb/notebook/challenge.py
+++ b/sagenb/notebook/challenge.py
@@ -27,7 +27,7 @@ AUTHORS:
 import os, random, re, urllib2, urllib
 
 from sagenb.notebook.template import template
-from flaskext.babel import gettext, lazy_gettext
+from flask.ext.babel import gettext, lazy_gettext
 _ = lazy_gettext
 
 class ChallengeResponse(object):

--- a/sagenb/notebook/conf.py
+++ b/sagenb/notebook/conf.py
@@ -9,7 +9,7 @@ Configuration
 #  The full text of the GPL is available at:
 #                  http://www.gnu.org/licenses/
 #############################################################################
-from flaskext.babel import gettext, lazy_gettext
+from flask.ext.babel import gettext, lazy_gettext
 
 POS = 'pos'
 DESC = 'desc'

--- a/sagenb/notebook/notebook.py
+++ b/sagenb/notebook/notebook.py
@@ -45,7 +45,7 @@ from . import server_conf  # server configuration
 from . import user_conf    # user configuration
 from . import user         # users
 from   template import template, prettify_time_ago
-from flaskext.babel import gettext, lazy_gettext
+from flask.ext.babel import gettext, lazy_gettext
 
 try:
     # sage is installed

--- a/sagenb/notebook/register.py
+++ b/sagenb/notebook/register.py
@@ -12,7 +12,7 @@
 """
 Helper functions dealing with the verification of user  
 """
-from flaskext.babel import gettext as _
+from flask.ext.babel import gettext as _
 
 def build_msg(key, username, addr, port, secure):
     url_prefix = "https" if secure else "http"

--- a/sagenb/notebook/server_conf.py
+++ b/sagenb/notebook/server_conf.py
@@ -8,7 +8,7 @@ import conf
 from conf import (POS, DESC, GROUP, TYPE, CHOICES, T_BOOL, T_INTEGER,
                   T_CHOICE, T_REAL, T_COLOR, T_STRING, T_LIST, T_INFO)
 from sagenb.misc.misc import get_languages
-from flaskext.babel import gettext, lazy_gettext
+from flask.ext.babel import gettext, lazy_gettext
 _ = lazy_gettext
 
 defaults = {'word_wrap_cols':72,

--- a/sagenb/notebook/template.py
+++ b/sagenb/notebook/template.py
@@ -21,7 +21,7 @@ import os, re, sys, json
 
 from sagenb.misc.misc import SAGE_VERSION, DATA, unicode_str
 from sagenb.notebook.cell import number_of_rows
-from flaskext.babel import gettext, ngettext, lazy_gettext
+from flask.ext.babel import gettext, ngettext, lazy_gettext
 
 if os.environ.has_key('SAGENB_TEMPLATE_PATH'):
     if not os.path.isdir(os.environ['SAGENB_TEMPLATE_PATH']):

--- a/sagenb/notebook/tutorial.py
+++ b/sagenb/notebook/tutorial.py
@@ -348,7 +348,7 @@ the "save" command), and get back to where you were quickly.
 
 #####################################
 
-from flaskext.babel import lazy_gettext as _
+from flask.ext.babel import lazy_gettext as _
 
 notebook_help = [
     (_('Find Help and Documentation'),

--- a/sagenb/notebook/user_conf.py
+++ b/sagenb/notebook/user_conf.py
@@ -7,7 +7,7 @@ import server_conf
 from conf import (Configuration, POS, DESC, GROUP, TYPE, CHOICES, T_BOOL,
                   T_INTEGER, T_CHOICE, T_REAL, T_COLOR, T_STRING, T_LIST)
 from sagenb.misc.misc import SAGENB_ROOT, get_languages
-from flaskext.babel import lazy_gettext
+from flask.ext.babel import lazy_gettext
 
 defaults = {'max_history_length':1000,
             'default_system':'sage',

--- a/sagenb/notebook/worksheet.py
+++ b/sagenb/notebook/worksheet.py
@@ -57,7 +57,7 @@ from sagenb.misc.format import relocate_future_imports
 # Imports specifically relevant to the sage notebook
 from cell import Cell, TextCell
 from template import template, clean_name, prettify_time_ago
-from flaskext.babel import gettext, lazy_gettext
+from flask.ext.babel import gettext, lazy_gettext
 _ = gettext
 
 # Set some constants that will be used for regular expressions below.
@@ -4288,7 +4288,7 @@ def convert_time_to_string(t):
     Converts ``t`` (in Unix time) to a locale-specific string
     describing the time and date.
     """
-    from flaskext.babel import format_datetime
+    from flask.ext.babel import format_datetime
     import datetime, time
     try:
         return format_datetime(datetime.datetime.fromtimestamp(float(t)))


### PR DESCRIPTION
Naming your Flask extension module "flaskext.foo" is now discouraged in
favor of naming it "flask_foo". To accommodate both styles, Flask 0.8
and higher allows you to import "flask.ext.foo", which will first try
"flask_foo" and then try "flaskext.foo". We should do this for all our
flask extension imports.

In the short term, this allows sagenb to build against the latest
version of Flask-AutoIndex, i.e. it deals with the following commit:
https://github.com/sublee/flask-autoindex/commit/2138855d69a124cdaad
