### PR TITLE
Workaround for Sphinx appending to sys.path

### DIFF
--- a/sagenb/misc/sphinxify.py
+++ b/sagenb/misc/sphinxify.py
@@ -76,6 +76,12 @@ def sphinxify(docstring, format='html'):
         'x=y\n'
         sage: sphinxify(':math:`x=y`', format='text')
         'x=y\n'
+
+    TESTS::
+
+        sage: n = len(sys.path)
+        sage: _ = sphinxify('A test')
+        sage: assert n == len(sys.path)
     """
     global Sphinx
     if not Sphinx:
@@ -109,9 +115,12 @@ def sphinxify(docstring, format='html'):
     doctreedir = os.path.join(srcdir, 'doctrees')
     confoverrides = {'html_context': {}, 'master_doc': 'docstring'}
 
+    import sys
+    old_sys_path = list(sys.path)  # Sphinx modifies sys.path
     sphinx_app = Sphinx(srcdir, confdir, srcdir, doctreedir, format,
                         confoverrides, None, None, True)
     sphinx_app.build(None, [rst_name])
+    sys.path = old_sys_path
 
     #We need to remove "_" from __builtin__ that the gettext module installs
     import __builtin__


### PR DESCRIPTION
The sphinxify() command ends up appending to sys.path all the time, this is at the root of http://trac.sagemath.org/12781
