### PR TITLE
Relax interact check for cells to allow passing options

### DIFF
--- a/sagenb/notebook/cell.py
+++ b/sagenb/notebook/cell.py
@@ -1281,7 +1281,7 @@ class Cell(Cell_generic):
             return False
         s = s[0]
         return bool(re.search('(?<!\w)interact\s*\(.*\).*', s) or
-                    re.search('\s*@\s*interact\s*\n', s))
+                    re.search('\s*@\s*interact', s))
 
     def is_interacting(self):
         r"""


### PR DESCRIPTION
Solves 2 of the problems on http://trac.sagemath.org/sage_trac/ticket/14020

The fix is to detect interact cells by searching for "@interact" without requiring new line in the end (which is not the case when there are parameters like layout). This is not the most ideal fix, but looking at the output instead of input is more involved, so I'd rather save it for later.

Thanks to Jason for figuring everything out, I just used it as some git practice.
