### PR TITLE
Set default timeout to 0 as documented and make it configurable

### DIFF
--- a/sagenb/notebook/run_notebook.py
+++ b/sagenb/notebook/run_notebook.py
@@ -449,7 +449,7 @@ def notebook_run(self,
              server_pool   = None,
              ulimit        = '',
 
-             timeout       = 0,   # timeout for normal worksheets. This is the
+             timeout       = None,   # timeout for normal worksheets. This is the
                                   # same as idle_timeout in server_conf.py
              doc_timeout   = None, # timeout for documentation worksheets
 
@@ -533,7 +533,8 @@ def notebook_run(self,
     if not quiet:
         print "The notebook files are stored in:", nb._dir
 
-    nb.conf()['idle_timeout'] = int(timeout)
+    if timeout is not None:
+        nb.conf()['idle_timeout'] = int(timeout)
     if doc_timeout is not None:
         nb.conf()['doc_timeout'] = int(doc_timeout)
 

--- a/sagenb/notebook/server_conf.py
+++ b/sagenb/notebook/server_conf.py
@@ -14,7 +14,7 @@ _ = lazy_gettext
 defaults = {'word_wrap_cols':72,
             'max_history_length':250,
 
-            'idle_timeout': 120,        # timeout in seconds for worksheets
+            'idle_timeout': 0,        # timeout in seconds for worksheets
             'doc_timeout': 600,         # timeout in seconds for live docs
             'idle_check_interval':360,
 


### PR DESCRIPTION
Solves #164: regular worksheets do not timeout at all unless configured otherwise by the user and timeout is configurable now through the web interface (currently anything entered there is reset on each start).
