### PR TITLE
Use the Sage displayhook, otherwise graphics is not shown (trac #14469)

### DIFF
--- a/sagenb/misc/support.py
+++ b/sagenb/misc/support.py
@@ -31,7 +31,7 @@ except ImportError:
 
 try:
     from sagenb.misc.sphinxify import sphinxify, is_sphinx_markup
-except ImportError, msg:
+except ImportError as msg:
     print msg
     print "Sphinx docstrings not available."
     # Don't do any Sphinxifying if sphinx's dependencies aren't around
@@ -39,6 +39,14 @@ except ImportError, msg:
         return s
     def is_sphinx_markup(s):
         return False
+
+try:
+    from sage.misc.displayhook import DisplayHook
+    sys.displayhook = DisplayHook()
+except ImportError as msg:
+    print msg
+    print 'Graphics will not be shown automatically'
+
 
 ######################################################################
 # Initialization


### PR DESCRIPTION
repr() of a graphics object used to display the graphics as a side-effect. I stopped this insanity at http://trac.sagemath.org/14469. But now the notebook needs to be smarter about when to call show(). The easiest solution is to just use the displayhook that we are also using for doctesting (but without DOCTEST_MODE, of course).
