### PR TITLE
allow groups and others r-x permissions

### DIFF
--- a/sagenb/misc/misc.py
+++ b/sagenb/misc/misc.py
@@ -408,6 +408,12 @@ def set_permissive_permissions(filename):
              stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR | \
              stat.S_IRGRP | stat.S_IWGRP | stat.S_IXGRP)
 
+def set_medium_permissions(filename, allow_execute=False):
+    x = stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR | stat.S_IRGRP | stat.S_IROTH
+    if allow_execute:
+        x = x | stat.S_IXGRP | stat.S_IXOTH
+    os.chmod(filename, x)
+
 def encoded_str(obj, encoding='utf-8'):
     ur"""
     Takes an object and returns an encoded str human-readable representation.

--- a/sagenb/notebook/cell.py
+++ b/sagenb/notebook/cell.py
@@ -19,7 +19,7 @@ import shutil
 from cgi import escape
 
 from sagenb.misc.misc import (word_wrap, strip_string_literals,
-                              set_restrictive_permissions, unicode_str,
+                              set_medium_permissions, unicode_str,
                               encoded_str)
 from interact import (INTERACT_RESTART, INTERACT_UPDATE_PREFIX,
                       INTERACT_TEXT, INTERACT_HTML)
@@ -972,7 +972,7 @@ class Cell(Cell_generic):
         dir = self._directory_name()
         if not os.path.exists(dir):
             os.makedirs(dir)
-        set_restrictive_permissions(dir)
+        set_medium_permissions(dir, allow_execute=True)
         return dir
 
     def _directory_name(self):

--- a/sagenb/notebook/worksheet.py
+++ b/sagenb/notebook/worksheet.py
@@ -41,7 +41,7 @@ import locale
 from sagenb.misc.misc import (cython, load, save,
                               alarm, cancel_alarm, verbose, DOT_SAGENB,
                               walltime, ignore_nonexistent_files,
-                              set_restrictive_permissions,
+                              set_medium_permissions,
                               set_permissive_permissions,
                               encoded_str, unicode_str)
 
@@ -256,9 +256,9 @@ class Worksheet(object):
         # creating directories should be a function of the storage backend, not here
         if not os.path.exists(self.__dir):
             os.makedirs(self.__dir)
-            set_restrictive_permissions(self.__dir, allow_execute=True)
-            set_restrictive_permissions(self.snapshot_directory())
-            set_restrictive_permissions(self.cells_directory())
+            set_medium_permissions(self.__dir, allow_execute=True)
+            set_medium_permissions(self.snapshot_directory(), allow_execute=True)
+            set_medium_permissions(self.cells_directory(), allow_execute=True)
 
     def id_number(self):
         """
@@ -3293,7 +3293,7 @@ except (KeyError, IOError):
                                             ignore=ignore_nonexistent_files)
                         else:
                             shutil.copy(X, target)
-                        set_restrictive_permissions(target)
+                        set_medium_permissions(target)
                         if os.path.isfile(X):
                             try: 
                                 os.unlink(X)


### PR DESCRIPTION
This fixes the bug in sage-5.4 and later where the user would not
be able to access 3D jmol plots if the server was being run with
a server_pool setup
