### PR TITLE
change URL for bug report

### DIFF
--- a/sagenb/data/sage/js/notebook_lib.js
+++ b/sagenb/data/sage/js/notebook_lib.js
@@ -4626,7 +4626,7 @@ function bugreport() {
     /*
     Popup the bug report window.
     */
-    window.open("http://spreadsheets.google.com/viewform?key=pCwvGVwSMxTzT6E2xNdo5fA", "", "menubar=1,location=1,scrollbars=1,width=800,height=650,toolbar=1,  resizable=1");
+    window.open("http://sagemath.org/report-issue", "", "menubar=1,location=1,scrollbars=1,width=800,height=650,toolbar=1,  resizable=1");
 }
 
 

--- a/sagenb/data/sage/js/ws_list.js
+++ b/sagenb/data/sage/js/ws_list.js
@@ -227,7 +227,7 @@ function bugreport() {
     /*
       Popup the bug report window.
     */
-    window.open('http://spreadsheets.google.com/viewform?key=pCwvGVwSMxTzT6E2xNdo5fA', '', 'menubar=1,location=1,scrollbars=1,width=800,height=650,toolbar=1,resizable=1');
+    window.open('http://sagemath.org/report-issue', '', 'menubar=1,location=1,scrollbars=1,width=800,height=650,toolbar=1,resizable=1');
 }
 
 function empty_trash() {


### PR DESCRIPTION
The URL for bug reports now goes to a sagemath.org link
that provides a 301 redirect to whatever is the best
current or future bug reporting platform.
