### PR TITLE
change URL for bug report

### DIFF
--- a/sagenb/data/sage/js/sagenb.js
+++ b/sagenb/data/sage/js/sagenb.js
@@ -46,7 +46,7 @@ sagenb.init = function() {
 	
 	$("#log").click(sagenb.history_window);
 	$("#report_a_problem").click(function(e) {
-		window.open('http://spreadsheets.google.com/viewform?key=pCwvGVwSMxTzT6E2xNdo5fA', '', 'menubar=1,location=1,scrollbars=1,width=800,height=650,toolbar=1,resizable=1');
+		window.open('http://sagemath.org/report-issue', '', 'menubar=1,location=1,scrollbars=1,width=800,height=650,toolbar=1,resizable=1');
 	});
 	$("#help").click(sagenb.help);
 	$(document).bind("keydown", "F1", function(evt) { sagenb.help(); return false; });


### PR DESCRIPTION
The URL for bug reports now goes to a sagemath.org link
that provides a 301 redirect to whatever is the best
current or future bug reporting platform.
