### PR TITLE
sagenb is not zip safe

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,4 +69,5 @@ if __name__ == '__main__':
                               all_files('sagenb/data', 'sagenb/') +
                               all_files('sagenb/translations', 'sagenb/')
                          },
+          zip_safe     = False,
           )


### PR DESCRIPTION
This is required for newer versions of setuptools which will zip up sagenb when installing.
