### PR TITLE
make \color in MathJax behave similar to \color in LaTeX

### DIFF
--- a/sagenb/data/sage/js/mathjax_sage.js
+++ b/sagenb/data/sage/js/mathjax_sage.js
@@ -28,7 +28,10 @@ MathJax.Hub.Config({
     TeX: {
 	Macros: {
 	    {{ theme_mathjax_macros|join(',\n') }}
-	}
+	},
+    // the following makes \color in MathJax compatible with the \color
+    // command from LaTeX
+    extensions: ["color.js"]
     },
 
 });


### PR DESCRIPTION
Now the following code in a text cell will indeed result in a blue color for the first part.

```
$${\color{blue} x^2 = x \times x} \text{ not blue }$$
```
