### PR TITLE
Provide a more informative message when source code can not be displayed

### DIFF
--- a/sagenb/misc/support.py
+++ b/sagenb/misc/support.py
@@ -367,7 +367,8 @@ def source_code(s, globs, system='sage'):
         return html_markup(output)
     
     except (TypeError, IndexError), msg:
-        return html_markup("Source code for %s not available."%obj)
+        return html_markup("Source code for {} is not available.".format(s) +
+                           "\nUse {}? to see the documentation.".format(s))
     
 def tabulate(v, width=90, ncols=3):
     e = len(v)


### PR DESCRIPTION
This happens for example when running the following:
import scipy
scipy.sin??

This fixes #207
