### PR TITLE
Po and pot management utility

### DIFF
--- a/util/translations.py
+++ b/util/translations.py
@@ -140,6 +140,7 @@ class LocalData(object):
             'dgettext': (2,),
             'dngettext': (2, 3),
             'N_': None,
+            'nN_': (1,2),
             'pgettext': ((1, 'c'), 2),
             'npgettext': ((1, 'c'), 2, 3),
             'lazy_gettext': None,
@@ -488,8 +489,8 @@ class TranslationFrontend(object):
 
         parser_update = subparsers.add_parser(
             'update', parents=(pot_parser, langs_parser, backup_parser),
-            help='updates pot and/or po files from sources',
-            description='updates pot and/or po files from source tree',
+            help='update pot and/or po files from sources',
+            description='update pot and/or po files from source tree',
             epilog='Warning: If backup is active, previous backup files '
                    'are overwritten',
             formatter_class=argparse.RawTextHelpFormatter,
@@ -521,8 +522,8 @@ class TranslationFrontend(object):
 
         parser_restore = subparsers.add_parser(
             'restore', parents=(pot_parser, langs_parser),
-            help='restores pot and/or po from backup files',
-            description='restores pot and/or po from backup files if exist',
+            help='restore pot and/or po from backup files',
+            description='restore pot and/or po from backup files if exist',
             epilog='Warning: If a particular backup file is not present, '
                    'the corresponding file\n'
                    '         is not restored',


### PR DESCRIPTION
Currently the messages template for translations is outdated, specially the references to sources. Also the localizations are outdated. I have implemented a small utility to easily accomplish maintenance task on translations. It encapsulates some `pybabel` functionality, adapted to the Sage Notebook source tree. Also it performs some tasks not directly available from `pybabel`. For example, we can now update translations directly from the source tree without any intermediate template file (`pot`). Only the public API of the `babel` package is used.

The utility has a detailed buitin help. Issue `/path_to_sagenb_source/utility/translations.py -h` on the command line for help. Warnings about the need of manual review on update are issued on demand.

TODO: 
- `sagenb/babel.cfg` is no more neccessary.
- No need to mantain a `sagenb/message.pot`. Updates of existing translations (with manual review, of course) from the source tree can be done, and also new translation initializatiions.
- Update and review of all the translations.
- Changes in the help text.
