### PR TITLE
Make snapshots work again

### DIFF
--- a/sagenb/data/sage/css/main.css
+++ b/sagenb/data/sage/css/main.css
@@ -274,6 +274,7 @@ button.add_new_worksheet_menu { font-size: 14px; }
 
 /* line 479, ../../../../sass/src/main.scss */
 #specific-revision-page #revision-data { padding: 1em 0.5em; border-top: 1px solid #c9d7f1; border-bottom: 1px solid #c9d7f1; }
+#specific-revision-page .sharebar a { color: white; border-left: 2px white solid; padding-left: 1em; }
 
 /* line 485, ../../../../sass/src/main.scss */
 #revision-list-page #revision-list { width: 100%; }

--- a/sagenb/data/sage/html/notebook/worksheet_revision_list.html
+++ b/sagenb/data/sage/html/notebook/worksheet_revision_list.html
@@ -3,7 +3,7 @@
 {% block page_id %}revision-list-page{% endblock %}
 
 {% block sharebar_title %}
-{{ gettext('Revision History -- Previous sessions') }}
+{{ gettext('Revision History -- List of Snapshots') }}
 {% endblock %}
 
 {% set select = "revisions" %}

--- a/sagenb/notebook/notebook.py
+++ b/sagenb/notebook/notebook.py
@@ -451,11 +451,11 @@ class Notebook(object):
         try:
             return self.__scratch_worksheet
         except AttributeError:
-            W = self.create_new_worksheet('scratch', '_sage_', add_to_list=False)
+            W = self.create_new_worksheet('scratch', '_sage_')
             self.__scratch_worksheet = W
             return W
 
-    def create_new_worksheet(self, worksheet_name, username, add_to_list=True):
+    def create_new_worksheet(self, worksheet_name, username):
         if username!='pub' and self.user_manager().user_is_guest(username):
             raise ValueError("guests cannot create new worksheets")
 
@@ -1355,6 +1355,7 @@ class Notebook(object):
         filename = ws.get_snapshot_text_filename(rev)
         txt = bz2.decompress(open(filename).read())
         W = self.scratch_worksheet()
+        W.set_name('Revision of ' + ws.name())
         W.delete_cells_directory()
         W.edit_save(txt)
 
@@ -1371,7 +1372,7 @@ class Notebook(object):
 
         return template(os.path.join("html", "notebook", 
                                      "specific_revision.html"),
-                        worksheet = ws,
+                        worksheet = W, # the revision, not the original!
                         username = username, rev = rev, prev_rev = prev_rev,
                         next_rev = next_rev, time_ago = time_ago)
 

--- a/sass/src/main.scss
+++ b/sass/src/main.scss
@@ -485,7 +485,11 @@ button.add_new_worksheet_menu {
   #revision-data {
     padding: 1em 0.5em;
     border-top: 1px solid #c9d7f1;
-    border-bottom: 1px solid #c9d7f1; } }
+    border-bottom: 1px solid #c9d7f1; }
+  .sharebar a {
+    color: white;
+    border-left: 2px white solid;
+    padding-left: 1em;} }
 
 #revision-list-page {
   #revision-list {


### PR DESCRIPTION
Clicking on a revision now actually takes
you to the correct revision.  Also fixed
some presentation issues for clarity.
