### PR TITLE
Fix path for babel

### DIFF
--- a/sagenb/babel.cfg
+++ b/sagenb/babel.cfg
@@ -3,7 +3,7 @@
 #It'll create the file /path/to/project/name_of_project.pot
 [python: **/sagenb/notebook/**.py]
 
-[python: **/flask_version/**.py]
+[python: **/sagenb/flask_version/**.py]
 
 [jinja2: **/sagenb/data/sage/html/**.html]
 encoding = utf-8


### PR DESCRIPTION
babel.cfg was not updated when we moved flask_version
