### PR TITLE
Create nodoctest.py

### DIFF
--- a/sagenb/testing/grinder/nodoctest.py
+++ b/sagenb/testing/grinder/nodoctest.py
@@ -1,0 +1,10 @@
+"""
+This directory contains files related to using Grinder
+(http://grinder.sourceforge.net/) to do testing of the
+Sage notebook server. The imports necessary to even load
+these files do not work without a Grinder instance running,
+and there is also some hard-coding that you would need to
+fix to use it, so we do not run tests. However, the Grinder
+objects could be useful to someone seeking an alternative
+to Selenium testing.
+"""


### PR DESCRIPTION
This should fix the doctest errors in sagenb, as well as give a tiny bit of info to anyone seeking to use Grinder with sagenb.
This would fix #281 as well.
