### PR TITLE
Disallow spellcheck in code cells

### DIFF
--- a/sagenb/data/sage/html/notebook/cell.html
+++ b/sagenb/data/sage/html/notebook/cell.html
@@ -82,7 +82,7 @@ INPUT:
                 <div class="cell_input_print">{{ cell.input_text().rstrip()|escape }}&nbsp;</div>
             {% else %}
                 <textarea class="{{ input_cls }}" rows="{{ (1, cell.input_text().strip()|number_of_rows(80))|max }}"
-                          cols="80"
+                          cols="80" spellcheck="false"
                           id="cell_input_{{ cell.id() }}">{{ cell.input_text().rstrip() }}</textarea>
                 <input type="button"
                    class="eval_button"


### PR DESCRIPTION
Given that there are going to be a lot of bizarre words in a code cell input area in sagenb, it seems best to disallow spell-checking there.  If you agree, merge this!

This would fix #276 
