### PR TITLE
Cache bust canvas3d so they reload properly

### DIFF
--- a/sagenb/notebook/cell.py
+++ b/sagenb/notebook/cell.py
@@ -2431,7 +2431,7 @@ class Cell(Cell_generic):
                 # jmol data
                 jmoldatafile=os.path.join(self.directory(),F)
             elif F.endswith('.canvas3d'):
-                script = '<div><script>canvas3d.viewer("%s");</script></div>' % url
+                script = '<div><script>canvas3d.viewer("%s?%s");</script></div>' %(url,time.time())
                 images.append(script)
             elif F.startswith('.jmol_'):
                 # static jmol data and images


### PR DESCRIPTION
This is a very minimal fix that works beautifully.  This should fix #255 and Sage Trac http://trac.sagemath.org/ticket/11275 as well.

No point in moving to Python 3 formatting for that part of the file just for this.
