### PR TITLE
Make fixed format Fortran work in sagenb

### DIFF
--- a/sagenb/notebook/cell.py
+++ b/sagenb/notebook/cell.py
@@ -1451,7 +1451,9 @@ class Cell(Cell_generic):
                 break
 
         self._percent_directives = directives
-        return "\n".join(text[i:]).strip()
+        if not self._system == 'fortran':
+            return "\n".join(text[i:]).strip()
+        return "\n".join(text[i:]).rstrip()
 
     def percent_directives(self):
         r"""


### PR DESCRIPTION
Because we strip the entire first line after a percent directive, fortran (which requires exact spacing in old versions) does not work properly if the first true line is not a comment.

Should fix #288.
