### PR TITLE
Allow custom label in shortcut matrix creation in interact

### DIFF
--- a/sagenb/notebook/interact.py
+++ b/sagenb/notebook/interact.py
@@ -3767,7 +3767,7 @@ def automatic_control(default):
         else:
             C = slider(list(default), default=default_value, label=label)
     elif is_Matrix(default):
-        C = input_grid(default.nrows(), default.ncols(), default=default.list(), to_value=default.parent())
+        C = input_grid(default.nrows(), default.ncols(), default=default.list(), to_value=default.parent(), label=label)
     else:
         C = input_box(default, label=label)
 


### PR DESCRIPTION
This was a nice fix Jason Grout suggested at http://trac.sagemath.org/ticket/8738 a long, long time ago that we never took care of.
