### PR TITLE
Crash when a non-existent collaborator is added to a worksheet

### DIFF
--- a/sagenb/flask_version/worksheet.py
+++ b/sagenb/flask_version/worksheet.py
@@ -591,14 +591,14 @@ def worksheet_invite_collab(worksheet):
     for u in collaborators-old_collaborators:
         try:
             user_manager.user(u).viewable_worksheets().add((owner, id_number))
-        except LookupError:
+        except (ValueError, LookupError):
             # user doesn't exist
             pass
     # remove worksheet from ex-collaborators
     for u in old_collaborators-collaborators:
         try:
             user_manager.user(u).viewable_worksheets().discard((owner, id_number))
-        except LookupError:
+        except (ValueError, LookupError):
             # user doesn't exist
             pass
 


### PR DESCRIPTION
When a non-existent user name is added to the collaborators list of a worksheet, the notebook crashed. As a side effect, we also get a crash when all the collaborators are deleted from a previously shared worksheet (the bug affected me in this way).

The cause is similar to that pointed out at Pull request #219.
