### PR TITLE
Provisional workaround to sanitize rating comments

### DIFF
--- a/sagenb/flask_version/worksheet.py
+++ b/sagenb/flask_version/worksheet.py
@@ -1,7 +1,7 @@
 import re
 import os, threading, collections
 from functools import wraps
-from flask import Module, make_response, url_for, render_template, request, session, redirect, g, current_app
+from flask import Module, make_response, url_for, render_template, request, session, redirect, g, current_app, escape
 from decorators import login_required, with_lock
 from collections import defaultdict
 from werkzeug.utils import secure_filename
@@ -920,7 +920,7 @@ def worksheet_rate(worksheet):
         return current_app.message(_("Gees -- You can't fool the rating system that easily!"),
                           url_for_worksheet(worksheet))
 
-    comment = request.values['comment']
+    comment = str(escape(request.values['comment']))
     worksheet.rate(rating, comment, g.username)
     s = _("""
     Thank you for rating the worksheet <b><i>%(worksheet_name)s</i></b>!


### PR DESCRIPTION
This solves (but not in an optimal manner) Issue #318. This problem arises because the jinja2 _automatic autoescape_ (flask default) is disabled in the Notebook. The particular Notebook implementation needs this feature disabled in multiple points, despite it is a major security threat. This might be (as usually occurs) related to Issue #319.

This commit only sanitizes the particular point causing the problem, but _automatic autoescape_ remains deactivated. Not good. I'm working in a better but more complex solution.
