### PR TITLE
Add needed files to manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,6 @@ graft sagenb
 graft sass
 graft util
 prune sass/src/.sass-cache
-include *.txt MANIFEST.in .gitignore dist.sh README.rst ReleaseInstr.md
+include *.txt *.rst *.md MANIFEST.in .gitignore dist.sh COPYING Changes
 prune .git
 global-exclude *.pyc *.pyo *.orig *.rej *~ \#* *\# *.sassc *.scssc *.DS_Store


### PR DESCRIPTION
A few text files were missing from the source dist because they weren't in the manifest.

This fixes #327.