### PR TITLE
Do not wrap HTML output in <pre>

### DIFF
--- a/sagenb/notebook/cell.py
+++ b/sagenb/notebook/cell.py
@@ -1797,14 +1797,14 @@ class Cell(Cell_generic):
 
         if raw:
             return s
-
+        s = s.strip('\n')
         pre_wrapping = len(s.strip()) > 0 and not \
             (is_interact or self.is_html() or '<div class="docstring">' in s)
         if html:
             s = self.parse_html(s, ncols, pre_wrapping)
         elif pre_wrapping:
-            s = '<pre class="shrunk">{}</pre>'.format(s.strip('\n'))
-        return s.strip('\n')
+            s = u'<pre class="shrunk">{}</pre>'.format(s)
+        return s
 
     def parse_html(self, s, ncols, pre_wrapping):
         r"""
@@ -1829,13 +1829,15 @@ class Cell(Cell_generic):
             sage: nb.user_manager().add_user('sage','sage','sage@sagemath.org',force=True)
             sage: W = nb.create_new_worksheet('Test', 'sage')
             sage: C = sagenb.notebook.cell.Cell(0, '2+3', '5', W)
-            sage: C.parse_html('<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN">\n<html><head></head><body>Test</body></html>', 80)
-            '&lt;!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0...Test</body>'
+            sage: C.parse_html('<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN">\n<html><head></head><body>Test</body></html>', 80, False)
+            '&lt;!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"&gt;\n<head></head><body>Test</body>'
+            sage: C.parse_html('<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN">\n<html><head></head><body>Test</body></html>', 80, True)
+            u'<pre class="shrunk">&lt;!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"&gt;\n</pre><head></head><body>Test</body>'
         """
         def format(x):
             x = word_wrap(escape(x), ncols)
             if pre_wrapping:
-                x = '<pre class="shrunk">{}</pre>'.format(x)
+                x = u'<pre class="shrunk">{}</pre>'.format(x)
             return x
 
         def format_html(x):


### PR DESCRIPTION
Currently HTML from html command is inserted into a `<pre>` block which means that you actually don't see real HTML output corresponding to your code. It also leads to extra dances for MathJax, we have our own parser for $ that replaces them with `<script>` tags. And I could not figure out how to turn on processing of environments. (My use case here: output a sequence "explanation formula explanation formula ..." which works way better in MathJax and LaTeX if each formula is a separate formula, rather than combining everything into a single math object.)

The change here is to wrap into `<pre>` every block which is NOT html - then we mostly have old behaviour, but HTML processing is now sensible and consistent with cell and cloud interfaces. (In particular, math environments are processed.)

Attaching sample output for before and after.
![before](https://cloud.githubusercontent.com/assets/1993227/10325735/518bca54-6c51-11e5-862f-b196814a15a8.png)
![after](https://cloud.githubusercontent.com/assets/1993227/10325737/575b4c7a-6c51-11e5-9823-884dea06f2d1.png)

