### PR TITLE
Revert "This is a change needed to support pexpect 3 and  up"

### DIFF
--- a/sagenb/interfaces/expect.py
+++ b/sagenb/interfaces/expect.py
@@ -277,7 +277,7 @@ class WorksheetProcess_ExpectImplementation(WorksheetProcess):
         if self._expect is None:
             self._is_computing = False
         else:
-            self._so_far = self._expect.before
+            self._so_far += self._expect.before
             
         import re
         v = re.findall('START%s.*%s'%(self._number,self._prompt), self._so_far, re.DOTALL)


### PR DESCRIPTION
Reverts sagemath/sagenb#351 temporarily to enable easier testing of downstream Sage ticket.