### PR TITLE
Live docs problems with autoescaping

### DIFF
--- a/sagenb/flask_version/worksheet.py
+++ b/sagenb/flask_version/worksheet.py
@@ -1,7 +1,7 @@
 import re
 import os, threading, collections
 from functools import wraps
-from flask import Module, make_response, url_for, render_template, request, session, redirect, g, current_app
+from flask import Module, make_response, url_for, render_template, request, session, redirect, g, current_app, Markup
 from decorators import login_required, with_lock
 from collections import defaultdict
 from werkzeug.utils import secure_filename
@@ -1038,7 +1038,8 @@ def worksheet_file(path):
 
     doc_page_html = open(path).read()
     from sagenb.notebook.docHTMLProcessor import SphinxHTMLProcessor
-    doc_page = SphinxHTMLProcessor().process_doc_html(doc_page_html)
+    doc_page = Markup(unicode_str(
+        SphinxHTMLProcessor().process_doc_html(doc_page_html))).unescape()
 
     title = (extract_title(doc_page_html).replace('&mdash;', '--') or
              'Live Sage Documentation')

--- a/sagenb/flask_version/worksheet.py
+++ b/sagenb/flask_version/worksheet.py
@@ -1,7 +1,7 @@
 import re
 import os, threading, collections
 from functools import wraps
-from flask import Module, make_response, url_for, render_template, request, session, redirect, g, current_app, Markup
+from flask import Module, make_response, url_for, render_template, request, session, redirect, g, current_app
 from decorators import login_required, with_lock
 from collections import defaultdict
 from werkzeug.utils import secure_filename
@@ -1038,8 +1038,7 @@ def worksheet_file(path):
 
     doc_page_html = open(path).read()
     from sagenb.notebook.docHTMLProcessor import SphinxHTMLProcessor
-    doc_page = Markup(unicode_str(
-        SphinxHTMLProcessor().process_doc_html(doc_page_html))).unescape()
+    doc_page = SphinxHTMLProcessor().process_doc_html(doc_page_html)
 
     title = (extract_title(doc_page_html).replace('&mdash;', '--') or
              'Live Sage Documentation')


### PR DESCRIPTION
As @kcrisman pointed out in #324, the new `autoescape` default for jinja2 templates breaks some live docs. Here is a possible solution to be tested. This solution does not break the fix for the *hidden* bugs found in #324 during the discussion of the problem.