### PR TITLE
Use Python's alarm() function

### DIFF
--- a/sagenb/misc/misc.py
+++ b/sagenb/misc/misc.py
@@ -123,13 +123,18 @@ def find_next_available_port(interface, start, max_tries=100, verbose=False):
         sage: find_next_available_port('127.0.0.1', 9000, verbose=False)   # random output -- depends on network
         9002
     """
+    from signal import alarm
+
     alarm_count = 0  
     for port in range(start, start+max_tries+1):
         try:
-            alarm(5)
-            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            s.connect((interface, port))
-        except socket.error, msg:
+            try:
+                alarm(5)
+                s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                s.connect((interface, port))
+            finally:
+                alarm(0)  # cancel alarm
+        except socket.error as msg:
             if msg[1] == 'Connection refused':
                 if verbose: print "Using port = %s"%port
                 return port
@@ -138,9 +143,6 @@ def find_next_available_port(interface, start, max_tries=100, verbose=False):
             alarm_count += 1
             if alarm_count >= 10:
                  break
-            pass 
-        finally:
-            cancel_alarm()
         if verbose:
             print "Port %s is already in use."%port
             print "Trying next port..."
@@ -260,15 +262,9 @@ except ImportError:
         open(filename,'wb').write(s)
 
 try:
-    from sage.misc.all import alarm, cancel_alarm, verbose
+    from sage.misc.all import verbose
 except ImportError:
     # TODO!
-    @stub
-    def alarm(*args, **kwds):
-        pass
-    @stub
-    def cancel_alarm(*args, **kwds):
-        pass
     @stub
     def verbose(*args, **kwds):
         pass

--- a/sagenb/notebook/worksheet.py
+++ b/sagenb/notebook/worksheet.py
@@ -38,8 +38,7 @@ import traceback
 import locale
 
 # General sage library code
-from sagenb.misc.misc import (cython, load, save,
-                              alarm, cancel_alarm, verbose, DOT_SAGENB,
+from sagenb.misc.misc import (cython, load, save, verbose, DOT_SAGENB,
                               walltime, ignore_nonexistent_files,
                               set_restrictive_permissions,
                               set_permissive_permissions,

--- a/sagenb/testing/stress.py
+++ b/sagenb/testing/stress.py
@@ -4,8 +4,11 @@ import urllib2
 
 
 from sage.misc.sage_timeit import sage_timeit
-from sage.misc.all import alarm, cancel_alarm
 from sagenb.misc.misc import walltime, cputime
+from signal import alarm
+
+def cancel_alarm():
+    alarm(0)
 
 
 TIMEOUT = 'timeout'


### PR DESCRIPTION
With the move of Sage's `alarm()` to the new [cysignals](https://github.com/sagemath/cysignals) package, importing `alarm` and `cancel_alarm` gives a deprecation warning. This is harmless, but we should no longer import `alarm` from Sage.

The easiest solution is simply to use Python's `alarm()` function, which works fine.