### PR TITLE
little cleanup of the except clauses (into python 2/3 compatible syntax)

### DIFF
--- a/sagenb/flask_version/worksheet_listing.py
+++ b/sagenb/flask_version/worksheet_listing.py
@@ -419,8 +419,8 @@ def upload_worksheet():
                         except RetrieveError as err:
                             return current_app.message(str(err), username=g.username)
                 W = g.notebook.import_worksheet(filename, g.username)
-        except Exception, msg:
-            print 'error uploading worksheet', msg
+        except Exception as msg:
+            print('error uploading worksheet {}'.format(msg))
             s = _('There was an error uploading the worksheet.  It could be an old unsupported format or worse.  If you desperately need its contents contact the <a href="http://groups.google.com/group/sage-support">sage-support group</a> and post a link to your worksheet.  Alternatively, an sws file is just a bzip2 tarball; take a look inside!\n%(backlinks)s', backlinks=backlinks)
             return current_app.message(s, url_for('home', username=g.username), username=g.username)
         finally:
@@ -431,7 +431,7 @@ def upload_worksheet():
                 import shutil
                 shutil.rmtree(dir)
 
-    except ValueError, msg:
+    except ValueError as msg:
         s = _("Error uploading worksheet '%(msg)s'.%(backlinks)s", msg=msg, backlinks=backlinks)
         return current_app.message(s, url_for('home', username=g.username), username=g.username)
 

--- a/sagenb/interfaces/reference.py
+++ b/sagenb/interfaces/reference.py
@@ -128,7 +128,7 @@ def execute_code(string, state, data=None):
     try:
         os.chdir(tempdir)
         exec string in state
-    except Exception, msg:
+    except Exception:
         traceback.print_exc(file=s)
     finally:
         sys.stdout = saved_stream

--- a/sagenb/misc/format.py
+++ b/sagenb/misc/format.py
@@ -177,6 +177,6 @@ def displayhook_hack(string):
                 compile(final_lines + '\n', '', 'single')
                 string[i] = "exec compile(%r + '\\n', '', 'single')" % final_lines
                 string = string[:i+1]
-            except SyntaxError, msg:
+            except SyntaxError:
                 pass
     return '\n'.join(string)

--- a/sagenb/misc/support.py
+++ b/sagenb/misc/support.py
@@ -32,8 +32,8 @@ except ImportError:
 try:
     from sagenb.misc.sphinxify import sphinxify, is_sphinx_markup
 except ImportError as msg:
-    print msg
-    print "Sphinx docstrings not available."
+    print(msg)
+    print("Sphinx docstrings not available.")
     # Don't do any Sphinxifying if sphinx's dependencies aren't around
     def sphinxify(s):
         return s
@@ -44,8 +44,8 @@ try:
     from sage.misc.displayhook import DisplayHook
     sys.displayhook = DisplayHook()
 except ImportError as msg:
-    print msg
-    print 'Graphics will not be shown automatically'
+    print(msg)
+    print('Graphics will not be shown automatically')
 
 
 ######################################################################
@@ -203,11 +203,11 @@ def completions(s, globs, format=False, width=90, system="None"):
                     v = [obj + '.'+x for x in D if x and x[0] != '_']
                 else:
                     v = [obj + '.'+x for x in D if x[:n] == method]
-            except Exception, msg:
+            except Exception:
                 v = []
         v = list(set(v))   # make unique
         v.sort()
-    except Exception, msg:
+    except Exception:
         v = []
 
     if prepend:
@@ -287,7 +287,7 @@ def docstring(obj_name, globs, system='sage'):
 def html_markup(s):
     try:
         from sagenb.misc.sphinxify import sphinxify, is_sphinx_markup
-    except ImportError, msg:
+    except ImportError:
         # sphinx not available
         def is_sphinx_markup(s): return False
 
@@ -366,7 +366,7 @@ def source_code(s, globs, system='sage'):
             output += src
         return html_markup(output)
     
-    except (TypeError, IndexError), msg:
+    except (TypeError, IndexError):
         return html_markup("Source code for {} is not available.".format(s) +
                            "\nUse {}? to see the documentation.".format(s))
     
@@ -563,7 +563,7 @@ try:
             try:
                 exec s in globals
                 return
-            except NameError, msg:
+            except NameError as msg:
                 # Determine if we hit a NameError that is probably
                 # caused by a variable or function not being defined:
                 if len(msg.args) == 0: raise  # not NameError with

--- a/sagenb/notebook/notebook.py
+++ b/sagenb/notebook/notebook.py
@@ -1960,7 +1960,7 @@ def migrate_old_notebook_v1(dir):
             if os.path.exists(dest): 
                 shutil.rmtree(dest)
             shutil.copytree(old_ws.data_directory(), dest)
-        except Exception, msg:
+        except Exception as msg:
             print(msg)
 
         try:
@@ -1969,7 +1969,7 @@ def migrate_old_notebook_v1(dir):
                 if os.path.exists(dest): 
                     shutil.rmtree(dest)
                 shutil.copytree(old_ws.cells_directory(), dest)
-        except Exception, msg:
+        except Exception as msg:
             print(msg)
 
 

--- a/sagenb/notebook/user.py
+++ b/sagenb/notebook/user.py
@@ -65,9 +65,9 @@ class User(object):
             try:
                 self.save_history()
                 del d['history']
-            except Exception, msg:
-                print msg
-                print "Unable to dump history of user %s to disk yet."%self._username
+            except Exception as msg:
+                print(msg)
+                print("Unable to dump history of user %s to disk yet." % self._username)
         return d
 
     def basic(self):

--- a/sagenb/notebook/worksheet.py
+++ b/sagenb/notebook/worksheet.py
@@ -2356,7 +2356,7 @@ class Worksheet(object):
             try:
                 meta, input, output, i = extract_first_compute_cell(text)
                 data.append(('compute', (meta, input, output)))
-            except EOFError, msg:
+            except EOFError as msg:
                 #print msg # -- don't print msg, just outputs a blank
                 #                 line every time, which makes for an
                 #                 ugly and unprofessional log.
@@ -2445,7 +2445,7 @@ class Worksheet(object):
         for cell in self.cell_list():
             try:
                 cells_html += cell.html(ncols, do_print=do_print, username=self.username) + '\n'
-            except Exception, msg:
+            except Exception as msg:
                 # catch any exception, since this exception is raised
                 # sometimes, at least for some worksheets:
                 # exceptions.UnicodeDecodeError: 'ascii' codec can't decode byte
@@ -2453,7 +2453,7 @@ class Worksheet(object):
                 # and this causes the entire worksheet to fail to
                 # save/render, which is obviously *not* good (much
                 # worse than a weird issue with one cell).
-                print msg
+                print(msg)
         return cells_html
 
     def html(self, do_print=False, publish=False, username=None):
@@ -2976,11 +2976,11 @@ class Worksheet(object):
 
         try:
             S.quit()
-        except AttributeError, msg:
-            print "WARNING: %s" % msg
-        except Exception, msg:
-            print msg
-            print "WARNING: Error deleting Sage object!"
+        except AttributeError as msg:
+            print("WARNING: %s" % msg)
+        except Exception as msg:
+            print(msg)
+            print("WARNING: Error deleting Sage object!")
 
         try:
             os.kill(pid, 9)
@@ -3053,9 +3053,9 @@ except (KeyError, IOError):
             S.execute(cmd)
             S.output_status()
 
-        except Exception, msg:
-            print "ERROR initializing compute process:\n"
-            print msg
+        except Exception as msg:
+            print("ERROR initializing compute process:\n")
+            print(msg)
             del self.__sage
             raise RuntimeError(msg)
 
@@ -3258,7 +3258,7 @@ except (KeyError, IOError):
 
         try:
             output_status = S.output_status()
-        except RuntimeError, msg:
+        except RuntimeError as msg:
             verbose("Computation was interrupted or failed. Restarting.\n%s" % msg)
             self.__comp_is_running = False
             self.start_next_comp()
@@ -3785,7 +3785,7 @@ except (KeyError, IOError):
                         l += k+1
                         I = C._before_preparse.split('\n')
                         out = out[:i + len(tb)+1] + '    ' + I[n-2] + out[l:]
-        except (ValueError, IndexError) as msg:
+        except (ValueError, IndexError):
             pass
         return out
 


### PR DESCRIPTION
I have converted the syntax from "except *Error, msg" (python2-only) to "except *Error as msg" 
which is py2/py3 compatible. Sometime removing the msg, when it was not used.

Reference:

http://python-future.org/compatible_idioms.html