### PR TITLE
turn again syntax of some except clauses to python3

### DIFF
--- a/sagenb/notebook/auth.py
+++ b/sagenb/notebook/auth.py
@@ -76,7 +76,7 @@ class LdapAuth(AuthMethod):
                 attrlist=attrlist,
                 timeout=self._conf['ldap_timeout'],
                 sizelimit=sizelimit)
-        except ldap.LDAPError, e:
+        except ldap.LDAPError as e:
             print('LDAP Error: %s' % str(e))
             return []
         finally:
@@ -123,7 +123,7 @@ class LdapAuth(AuthMethod):
             return True
         except ldap.INVALID_CREDENTIALS:
             return False
-        except ldap.LDAPError, e:
+        except ldap.LDAPError as e:
             print('LDAP Error: %s' % str(e))
             return False
         finally:

--- a/sagenb/notebook/run_notebook.py
+++ b/sagenb/notebook/run_notebook.py
@@ -348,7 +348,7 @@ reactor.addSystemEventTrigger('before', 'shutdown', partial(save_notebook2, flas
             else:
                 secure = False
             return interface, port, secure
-        except IOError, AttributeError:
+        except (IOError, AttributeError):
             return None, None, None
 
 

--- a/sagenb/simple/twist.py
+++ b/sagenb/simple/twist.py
@@ -214,7 +214,7 @@ class LoginResource(resource.Resource):
             U = notebook_twist.notebook.user(username)
             if not U.password_is(password):
                 raise ValueError # want to return the same error message
-        except KeyError, ValueError:
+        except (KeyError, ValueError):
             return http.Response(stream = "Invalid login.")
             
         worksheet = notebook_twist.notebook.create_new_worksheet("_simple_session_", username, add_to_list=False)
@@ -326,7 +326,7 @@ class StatusResource(CellResource):
             cell = session.worksheet.get_cell_with_id(cell_id)
             try:
                 timeout = float(ctx.args['timeout'][0])
-            except KeyError, ValueError:
+            except (KeyError, ValueError):
                 timeout = -1
             return self.start_comp(cell, timeout)
         except KeyError:


### PR DESCRIPTION
I forgot to add two "as" in previous pull requests. And also parentheses are required in 3 cases.