### PR TITLE
Use SAGE_SHARE instead of SAGE_ROOT for jsmol path

### DIFF
--- a/sagenb/flask_version/base.py
+++ b/sagenb/flask_version/base.py
@@ -38,12 +38,12 @@ class SageNBFlask(Flask):
         self.add_static_path('/javascript', DATA)
         self.add_static_path('/static', DATA)
         self.add_static_path('/java', DATA)
-        self.add_static_path('/java/jmol', os.path.join(os.environ["SAGE_ROOT"],"local","share","jmol"))
-        self.add_static_path('/jsmol', os.path.join(os.environ["SAGE_ROOT"],"local","share","jsmol"))
-        self.add_static_path('/jsmol/js', os.path.join(os.environ["SAGE_ROOT"],"local","share","jsmol","js"))
-        self.add_static_path('/j2s', os.path.join(os.environ["SAGE_ROOT"],"local","share","jsmol","j2s"))
-        self.add_static_path('/jsmol/j2s', os.path.join(os.environ["SAGE_ROOT"],"local","share","jsmol","j2s"))
-        self.add_static_path('/j2s/core', os.path.join(os.environ["SAGE_ROOT"],"local","share","jsmol","j2s","core"))
+        self.add_static_path('/java/jmol', os.path.join(os.environ["SAGE_LOCAL"],"share","jmol"))
+        self.add_static_path('/jsmol', os.path.join(os.environ["SAGE_LOCAL"],"share","jsmol"))
+        self.add_static_path('/jsmol/js', os.path.join(os.environ["SAGE_LOCAL"],"share","jsmol","js"))
+        self.add_static_path('/j2s', os.path.join(os.environ["SAGE_LOCAL"],"share","jsmol","j2s"))
+        self.add_static_path('/jsmol/j2s', os.path.join(os.environ["SAGE_LOCAL"],"share","jsmol","j2s"))
+        self.add_static_path('/j2s/core', os.path.join(os.environ["SAGE_LOCAL"],"share","jsmol","j2s","core"))
         import mimetypes
         mimetypes.add_type('text/plain','.jmol')
 

--- a/sagenb/flask_version/base.py
+++ b/sagenb/flask_version/base.py
@@ -38,12 +38,12 @@ class SageNBFlask(Flask):
         self.add_static_path('/javascript', DATA)
         self.add_static_path('/static', DATA)
         self.add_static_path('/java', DATA)
-        self.add_static_path('/java/jmol', os.path.join(os.environ["SAGE_LOCAL"],"share","jmol"))
-        self.add_static_path('/jsmol', os.path.join(os.environ["SAGE_LOCAL"],"share","jsmol"))
-        self.add_static_path('/jsmol/js', os.path.join(os.environ["SAGE_LOCAL"],"share","jsmol","js"))
-        self.add_static_path('/j2s', os.path.join(os.environ["SAGE_LOCAL"],"share","jsmol","j2s"))
-        self.add_static_path('/jsmol/j2s', os.path.join(os.environ["SAGE_LOCAL"],"share","jsmol","j2s"))
-        self.add_static_path('/j2s/core', os.path.join(os.environ["SAGE_LOCAL"],"share","jsmol","j2s","core"))
+        self.add_static_path('/java/jmol', os.path.join(os.environ["SAGE_SHARE"],"jmol"))
+        self.add_static_path('/jsmol', os.path.join(os.environ["SAGE_SHARE"],"jsmol"))
+        self.add_static_path('/jsmol/js', os.path.join(os.environ["SAGE_SHARE"],"jsmol","js"))
+        self.add_static_path('/j2s', os.path.join(os.environ["SAGE_SHARE"],"jsmol","j2s"))
+        self.add_static_path('/jsmol/j2s', os.path.join(os.environ["SAGE_SHARE"],"jsmol","j2s"))
+        self.add_static_path('/j2s/core', os.path.join(os.environ["SAGE_SHARE"],"jsmol","j2s","core"))
         import mimetypes
         mimetypes.add_type('text/plain','.jmol')
 


### PR DESCRIPTION
This will make it work on distros, where jsmol is typically installed in /usr/share