### PR TITLE
Bad relative import fixed

### DIFF
--- a/sagenb/notebook/all.py
+++ b/sagenb/notebook/all.py
@@ -17,4 +17,4 @@ from .notebook_object import notebook, inotebook
 from .interact import interact, input_box, slider, range_slider, selector, checkbox, input_grid, text_control, color_selector
 
 # For doctesting.
-from . import sagenb
+import sagenb


### PR DESCRIPTION
When running the notebook master branch with sage 7.2, we obtain things like this:

![sage-error](https://cloud.githubusercontent.com/assets/3618191/16179474/4d347e66-3667-11e6-8654-42d47a164b30.png)

The cause is a bad relative import in commit https://github.com/sagemath/sagenb/commit/89d3285f01920a4d2f5788102c5795e223e88f3e and this pull request fixes it.
