### PR TITLE
Circular import

### DIFF
--- a/sagenb/notebook/worksheet.py
+++ b/sagenb/notebook/worksheet.py
@@ -102,7 +102,6 @@ def update_worksheets():
     for S in all_worksheet_processes:
         S.update()
 
-from . import notebook as _notebook
 def worksheet_filename(name, owner):
     """
     Return the relative directory name of this worksheet with given


### PR DESCRIPTION
The commit https://github.com/sagemath/sagenb/commit/07de9c8df196e73f8e94a8ff39d02e7ee10a4c79 causes a circular import. This can be safely fixed by deleting the offending import (see [these lines](https://github.com/sagemath/sagenb/blob/master/sagenb/notebook/worksheet.py#L910-L936))