### PR TITLE
do not use cmp (for python3 compatibility)

### DIFF
--- a/sagenb/notebook/cell.py
+++ b/sagenb/notebook/cell.py
@@ -100,7 +100,7 @@ class Cell_generic(object):
         """
         return "Cell_generic %s" % self._id
 
-    def __cmp__(self, right):
+    def __lt__(self, right):
         """
         Compares generic cells by ID.
 
@@ -131,7 +131,7 @@ class Cell_generic(object):
             sage: [C1 == C2, C1 == C3, C2 == C3]
             [True, True, True]
         """
-        return cmp(self.id(), right.id())
+        return self.id() < right.id()
 
     def id(self):
         """

--- a/sagenb/notebook/conf.py
+++ b/sagenb/notebook/conf.py
@@ -174,14 +174,10 @@ class Configuration(object):
             s += u'<div class="section">\n  <h2>%s</h2>\n  <table>\n' % lazy_gettext(group)
 
             opts = G[group]
-            def sortf(x, y):
-                wx = DS[x].get(POS, POS_DEFAULT)
-                wy = DS[y].get(POS, POS_DEFAULT)
-                if wx == wy:
-                    return cmp(x, y)
-                else:
-                    return cmp(wx, wy)
-            opts.sort(sortf)
+
+            def sort_key(x):
+                return (DS[x].get(POS, POS_DEFAULT), x)
+            opts.sort(key=sort_key)
             for o in opts:
                 s += u'    <tr>\n      <td>%s</td>\n      <td>\n' % lazy_gettext(DS[o][DESC])
                 input_type = 'text'

--- a/sagenb/notebook/notebook.py
+++ b/sagenb/notebook/notebook.py
@@ -2052,21 +2052,23 @@ def sort_worksheet_list(v, sort, reverse):
     """
     f = None
     if sort == 'last_edited':
-        def c(a, b):
-            return -cmp(a.last_edited(), b.last_edited())
+        def c(a):
+            return a.last_edited()
+        reverse = not reverse
         f = c
     elif sort == 'name':
-        def c(a, b):
-            return cmp((a.name().lower(), -a.last_edited()), (b.name().lower(), -b.last_edited()))
+        def c(a):
+            return (a.name().lower(), -a.last_edited())
         f = c
     elif sort == 'owner':
-        def c(a, b):
-            return cmp((a.owner().lower(), -a.last_edited()), (b.owner().lower(), -b.last_edited()))
+        def c(a):
+            return (a.owner().lower(), -a.last_edited())
         f = c
     elif sort == "rating":
-        def c(a, b):
-            return -cmp((a.rating(), -a.last_edited()), (b.rating(), -b.last_edited()))
+        def c(a):
+            return (a.rating(), -a.last_edited())
+        reverse = not reverse
         f = c
     else:
         raise ValueError("invalid sort key '%s'" % sort)
-    v.sort(cmp = f, reverse=reverse)
+    v.sort(key=f, reverse=reverse)

--- a/sagenb/notebook/worksheet.py
+++ b/sagenb/notebook/worksheet.py
@@ -431,7 +431,7 @@ class Worksheet(object):
                 self.set_worksheet_that_was_published(value)
         self.create_directories()
 
-    def __cmp__(self, other):
+    def __lt__(self, other):
         """
         We compare two worksheets.
 
@@ -441,8 +441,7 @@ class Worksheet(object):
 
         OUTPUT:
 
-        -  ``-1,0,1`` - comparison is on the underlying
-           file names.
+        - boolean - comparison is on the underlying file names.
 
         EXAMPLES::
 
@@ -450,15 +449,12 @@ class Worksheet(object):
             sage: nb.create_default_users('password')
             sage: W2 = nb.create_new_worksheet('test2', 'admin')
             sage: W1 = nb.create_new_worksheet('test1', 'admin')
-            sage: cmp(W1, W2)
-            1
-            sage: cmp(W2, W1)
-            -1
+            sage: W1 <= W2
+            True
+            sage: W2 <= W1
+            False
         """
-        try:
-            return cmp(self.filename(), other.filename())
-        except AttributeError:
-            return cmp(type(self), type(other))
+        return self.filename() <= other.filename()
 
     def __repr__(self):
         r"""


### PR DESCRIPTION
For py3 compatibility, we should not use `cmp` at all.

I changed `__cmp__` to `__lt__` (not clear to me if this is correct).

I also replaced sorting by comparison to sorting by key (more clearly correct, I think).