### PR TITLE
import StringIO and CStringIO in py2/3 compatible way

### DIFF
--- a/sagenb/interfaces/reference.py
+++ b/sagenb/interfaces/reference.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*
 import os
-import StringIO
+from six import StringIO
 import sys
 import traceback
 import tempfile
@@ -125,7 +125,7 @@ def execute_code(string, state, data=None):
         # make a symbolic link from the data directory into local tmp directory
         os.symlink(data, os.path.join(tempdir, os.path.split(data)[1]))
     
-    s = StringIO.StringIO()
+    s = StringIO()
     saved_stream = sys.stdout
     sys.stdout = s
     try:

--- a/sagenb/notebook/colorize.py
+++ b/sagenb/notebook/colorize.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*
 """nodoctest
 """
-
-# -*- coding: utf-8 -*-
 #############################################################################
 #       Copyright (C) 2007 William Stein <wstein@gmail.com>
 #  Distributed under the terms of the GNU General Public License (GPL)
@@ -22,7 +20,7 @@
 import cgi
 import string
 import sys
-import cStringIO
+from six.moves import cStringIO as StringIO
 import keyword
 import token
 import tokenize
@@ -68,7 +66,7 @@ class Parser:
 
         # parse the source and write it
         self.pos = 0
-        text = cStringIO.StringIO(self.raw)
+        text = StringIO(self.raw)
         try:
             tokenize.tokenize(text.readline, self)
         except tokenize.TokenError as ex:
@@ -129,7 +127,7 @@ def colorize(source):
     """
     write colorized version to "[filename].py.html"
     """
-    html = cStringIO.StringIO()
+    html = StringIO()
     Parser(source, html).format(None, None)
     html.flush()
     html.seek(0)

--- a/sagenb/notebook/mailsender.py
+++ b/sagenb/notebook/mailsender.py
@@ -13,7 +13,7 @@ from twisted.application import service
 from twisted.application import internet
 from twisted.internet import protocol
 from twisted.mail import smtp, relaymanager
-from StringIO import StringIO
+from six import StringIO
 from email.MIMEBase import MIMEBase
 from email.MIMEMultipart import MIMEMultipart
 from email import Encoders

--- a/sagenb/testing/HTMLTestRunner.py
+++ b/sagenb/testing/HTMLTestRunner.py
@@ -111,7 +111,7 @@ CHANGES
 """
 import datetime
 import os
-from io import StringIO
+from six import StringIO
 import sys
 import unittest
 
@@ -247,7 +247,7 @@ class _TestResult(unittest.TestResult):
         """
         unittest.TestResult.startTest(self, test)
         # Just one buffer for both stdout and stderr.
-        self.outputBuffer = StringIO.StringIO()
+        self.outputBuffer = StringIO()
         stdout_redirector.fp = self.outputBuffer
         stderr_redirector.fp = self.outputBuffer
         self.stdout0 = sys.stdout


### PR DESCRIPTION
as another small step towards py3 compatibility, let us modernize the imports of StringIO and cStringIO