### PR TITLE
Fix hyperlinks on datafile page

### DIFF
--- a/sagenb/data/sage/html/notebook/download_or_delete_datafile.html
+++ b/sagenb/data/sage/html/notebook/download_or_delete_datafile.html
@@ -36,14 +36,14 @@ INPUT:
 {% endblock %}
 
 {% block after_sharebar %}
-<p>{{ gettext('You may download <a href="%(p)s">%(f)s</a> or create a link to this file in worksheet ', p=path, f=filename_) }} <select onchange="go_option(this);" class="worksheet">
+<p>{{ gettext('You may download <a href="%(p)s">%(f)s</a> or create a link to this file in worksheet ', p=path, f=filename_) |safe }} <select onchange="go_option(this);" class="worksheet">
 <option selected>{{ gettext('select worksheet') }}</option>
 {% for worksheet in notebook.active_worksheets_for(username) %}
     <option value='link_datafile("{{ worksheet.filename() }}","{{ filename_ }}")'>{{ worksheet.name() }}</option>
 {% endfor %}
-</select> {{ gettext('or <a href="/home/%(wf)s/datafile?name=%(f)s&action=delete">delete %(f)s.</a>', wf=worksheet.filename(), f=filename_) }}</p>
+</select> {{ gettext('or <a href="/home/%(wf)s/datafile?name=%(f)s&action=delete">delete %(f)s.</a>', wf=worksheet.filename(), f=filename_) |safe }}</p>
 
-<p>{{ gettext("Access %(f)s in this worksheet by typing <tt>DATA+'%(f)s'</tt>. Here DATA is a special variable that gives the exact path to all data files uploaded to this worksheet.", f=filename_) }}</p>
+<p>{{ gettext("Access %(f)s in this worksheet by typing <tt>DATA+'%(f)s'</tt>. Here DATA is a special variable that gives the exact path to all data files uploaded to this worksheet.", f=filename_) |safe }}</p>
 
 <hr class="usercontrol" />
 


### PR DESCRIPTION
In Sage-7.4 Notebook, Jinja2 replaces the HTML markup "<" and ">" by "&lt;" and "&gt;" respectively. In this commit a Jinja2 filter "safe" is used as suggested [here](http://flask.pocoo.org/docs/0.11/templating/#controlling-autoescaping).