### PR TITLE
Fix for UTF-8 data files

### DIFF
--- a/sagenb/notebook/notebook.py
+++ b/sagenb/notebook/notebook.py
@@ -1454,10 +1454,9 @@ class Notebook(object):
         if ext in ['.txt', '.tex', '.sage', '.spyx', '.py', '.f', '.f90', '.c']:
             file_is_text = True
             text_file_content = open(os.path.join(ws.data_directory(), filename)).read()
-            try:
-                text_file_content = text_file_content.decode('utf-8')
-            except UnicodeDecodeError:
-                text_file_content = text_file_content.decode('latin-1')
+            # Detect the character encoding
+            from BeautifulSoup import UnicodeDammit
+            text_file_content = UnicodeDammit(text_file_content).unicode
 
         return template(os.path.join("html", "notebook", "download_or_delete_datafile.html"),
                         worksheet = ws, notebook = self,

--- a/sagenb/notebook/notebook.py
+++ b/sagenb/notebook/notebook.py
@@ -1454,6 +1454,10 @@ class Notebook(object):
         if ext in ['.txt', '.tex', '.sage', '.spyx', '.py', '.f', '.f90', '.c']:
             file_is_text = True
             text_file_content = open(os.path.join(ws.data_directory(), filename)).read()
+            try:
+                text_file_content = text_file_content.decode('utf-8')
+            except:
+                text_file_content = text_file_content.decode('latin-1')
 
         return template(os.path.join("html", "notebook", "download_or_delete_datafile.html"),
                         worksheet = ws, notebook = self,

--- a/sagenb/notebook/notebook.py
+++ b/sagenb/notebook/notebook.py
@@ -1456,7 +1456,7 @@ class Notebook(object):
             text_file_content = open(os.path.join(ws.data_directory(), filename)).read()
             try:
                 text_file_content = text_file_content.decode('utf-8')
-            except:
+            except UnicodeDecodeError:
                 text_file_content = text_file_content.decode('latin-1')
 
         return template(os.path.join("html", "notebook", "download_or_delete_datafile.html"),


### PR DESCRIPTION
This fix is to address the issue [discussed on the mailing list](https://groups.google.com/d/topic/sage-support/EK9nOmx4lsQ/discussion).
In Sage-7.4 the Notebook cannot read the text files with UTF-8 encoding (and perhaps, other 8-bit encodings too).

The idea of the proposed patch is first to try to decode the text as UTF-8, and if it does not work, fall back to Latin-1 encoding. This is not a graceful solution indeed, and is definitely not a smart thing to do.
However, in this case even if the text file is not in Latin-1 encoding, but in some other (let's say, in cp1251), the Notebook will still print the file to the screen instead of just saying "500: Internal server error." In such case the user will _see_ that the problem is the encoding of the text file.