### PR TITLE
Fix `url_for` call to reference local blueprint endpoint (fixes #420)

### DIFF
--- a/sagenb/data/sage/html/settings/user_management.html
+++ b/sagenb/data/sage/html/settings/user_management.html
@@ -23,12 +23,12 @@
          <td><a href="/home/{{ u }}/">{{ u }}</a></td>
          <td>
             {% if not u.is_external() %}
-            <a href="{{ url_for('users', reset=u.username()) }}">{{ gettext('Reset') }}</a>
+            <a href="{{ url_for('.users', reset=u.username()) }}">{{ gettext('Reset') }}</a>
             {% endif %}
          </td>
-         <td><a href="{{ url_for('suspend_user', user=u.username()) }}">{% if u.is_suspended() %}{{ gettext('Unsuspend') }}{% else %}{{ gettext('Suspend') }}{% endif %}</a></td>
-         <td><a href="{{ url_for('toggle_admin', user=u.username()) }}">{% if u.is_admin() %}{{ gettext('Revoke') }}{% else %}{{ gettext('Grant') }}{% endif %}</a> </td>
-         <td><a href="{{ url_for('del_user', user=u.username()) }} ">{{ gettext('Delete') }}</a></td>
+         <td><a href="{{ url_for('.suspend_user', user=u.username()) }}">{% if u.is_suspended() %}{{ gettext('Unsuspend') }}{% else %}{{ gettext('Suspend') }}{% endif %}</a></td>
+         <td><a href="{{ url_for('.toggle_admin', user=u.username()) }}">{% if u.is_admin() %}{{ gettext('Revoke') }}{% else %}{{ gettext('Grant') }}{% endif %}</a> </td>
+         <td><a href="{{ url_for('.del_user', user=u.username()) }} ">{{ gettext('Delete') }}</a></td>
       </tr>
       {% endif %}
       {% endfor %}


### PR DESCRIPTION
Flask gets confused with original `url_for('users')` call as it does not know where to find the `users` endpoint. This issue can be fixed by addressing the local blueprint endpoint by prefixing a dot:

> In case blueprints are active you can shortcut references to the same blueprint by prefixing the local endpoint with a dot (.). ([Flask 0.12 documentation](http://flask.pocoo.org/docs/0.12/api/#flask.url_for))

Four lines calling `url_for` that result in a url build error from Flask are fixed to call the local endpoint.

Resolves #420.