### PR TITLE
Add path to threejs

### DIFF
--- a/sagenb/flask_version/base.py
+++ b/sagenb/flask_version/base.py
@@ -45,6 +45,7 @@ class SageNBFlask(Flask):
         self.add_static_path('/j2s', os.path.join(os.environ["SAGE_SHARE"],"jsmol","j2s"))
         self.add_static_path('/jsmol/j2s', os.path.join(os.environ["SAGE_SHARE"],"jsmol","j2s"))
         self.add_static_path('/j2s/core', os.path.join(os.environ["SAGE_SHARE"],"jsmol","j2s","core"))
+        self.add_static_path('/threejs', os.path.join(os.environ["SAGE_SHARE"],"threejs"))
         import mimetypes
         mimetypes.add_type('text/plain','.jmol')
 


### PR DESCRIPTION
In order for the new Three.js viewer to work offline in Sage notebooks, there needs to be a server path to the JavaScript files. This appears to be the place to add it, but correct me if I'm wrong.

Reference: https://trac.sagemath.org/ticket/22488