### PR TITLE
Fix docbuild with Sphinx 1.8.1

### DIFF
--- a/sagenb/misc/sphinxify.py
+++ b/sagenb/misc/sphinxify.py
@@ -85,14 +85,16 @@ def sphinxify(docstring, format='html'):
         from sphinx.application import Sphinx
 
     srcdir = mkdtemp()
-    base_name = os.path.join(srcdir, 'docstring')
-    rst_name = base_name + '.rst'
+    outdir = mkdtemp()
+    src_base_name = os.path.join(srcdir, 'docstring')
+    out_base_name = os.path.join(outdir, 'docstring')
+    rst_name = src_base_name + '.rst'
 
     if format == 'html':
         suffix = '.html'
     else:
         suffix = '.txt'
-    output_name = base_name + suffix
+    output_name = out_base_name + suffix
 
     with open(rst_name, 'w') as filed:
         filed.write(docstring)
@@ -113,7 +115,9 @@ def sphinxify(docstring, format='html'):
 
     import sys
     old_sys_path = list(sys.path)  # Sphinx modifies sys.path
-    sphinx_app = Sphinx(srcdir, confdir, srcdir, doctreedir, format,
+    # Sphinx constructor: Sphinx(srcdir, confdir, outdir, doctreedir,
+    # buildername, confoverrides, status, warning, freshenv).
+    sphinx_app = Sphinx(srcdir, confdir, outdir, doctreedir, format,
                         confoverrides, None, None, True)
     sphinx_app.build(None, [rst_name])
     sys.path = old_sys_path
@@ -138,7 +142,8 @@ def sphinxify(docstring, format='html'):
         # Remove spurious \(, \), \[, \].
         output = output.replace('\\(', '').replace('\\)', '').replace('\\[', '').replace('\\]', '')
     else:
-        print("BUG -- Sphinx error")
+        from warnings import warn
+        warn("Sphinx did not produce any output", Warning)
         if format == 'html':
             output = '<pre class="introspection">%s</pre>' % docstring
         else:
@@ -147,6 +152,7 @@ def sphinxify(docstring, format='html'):
     if temp_confdir:
         shutil.rmtree(confdir, ignore_errors=True)
     shutil.rmtree(srcdir, ignore_errors=True)
+    shutil.rmtree(outdir, ignore_errors=True)
 
     return output
 


### PR DESCRIPTION
Sphinx 1.8.1 doesn't allow outdir and srcdir to be the same directory. The patch applied is the same as for https://trac.sagemath.org/ticket/26451 since the `sphinxify.py` seems to be a copy.