### PR TITLE
Add initialization to docstring doctest

### DIFF
--- a/sagenb/misc/support.py
+++ b/sagenb/misc/support.py
@@ -246,9 +246,10 @@ def docstring(obj_name, globs, system='sage'):
     TESTS:
 
     Check that Trac 10860 is fixed and we can handle Unicode help
-    strings in the notebook::
+    strings in the notebook, see also Trac 26906::
 
-        sage: from sagenb.misc.support import docstring
+        sage: from sagenb.misc.support import init, docstring
+        sage: init()
         sage: D = docstring("r.lm", globs=globals())
     """
     if system not in ['sage', 'python']:


### PR DESCRIPTION
The fix of an issue related to introspection in Sage revealed an issue
with one of the doctests in sagenb. More specifically, before this
commit, `docstring` was called without first initializing the module,
but initialization is necessary so that `EMBEDDED_MODE` gets set, which
is needed to format docstrings correctly.

Apparently, this is just an issue with this specific doctest, and not
the notebook in general.

For more information, see https://trac.sagemath.org/ticket/26906.